### PR TITLE
autocrafter rewrite

### DIFF
--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -247,16 +247,18 @@ minetest.register_node("pipeworks:autocrafter", {
 		stack:set_count(count)
 		if from_list == "recipe" then
 			inv:set_stack(from_list, from_index, ItemStack(""))
-			after_recipe_change(pos, inv)
-			return 0
-		elseif to_list == "recipe" then
-			add_virtual_item(inv, to_list, to_index, stack)
-			after_recipe_change(pos, inv)
-			return 0
-		else
-			after_inventory_change(pos, inv)
-			return stack:get_count()
 		end
+		if to_list == "recipe" then
+			add_virtual_item(inv, to_list, to_index, stack)
+		end
+
+		if from_list == "recipe" or to_list == "recipe" then
+			after_recipe_change(pos, inv)
+			return 0
+		end
+
+		after_inventory_change(pos, inv)
+		return stack:get_count()
 	end,
 	on_timer = run_autocrafter
 })

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -1,5 +1,7 @@
 local autocrafterCache = {}  -- caches some recipe data to avoid to call the slow function minetest.get_craft_result() every second
 
+local craft_time = 1
+
 local function count_index(invlist)
 	local index = {}
 	for _, stack in pairs(invlist) do
@@ -57,14 +59,14 @@ local function on_recipe_change(pos, inventory)
 
 	local timer = minetest.get_node_timer(pos)
 	if not timer:is_started() then
-		timer:start(1)
+		timer:start(craft_time)
 	end
 end
 
 local function on_inventory_change(pos, inventory)
 	local timer = minetest.get_node_timer(pos)
 	if not timer:is_started() then
-		timer:start(1)
+		timer:start(craft_time)
 	end
 end
 
@@ -101,7 +103,12 @@ local function run_autocrafter(pos, elapsed)
 	local meta = minetest.get_meta(pos)
 	local inventory = meta:get_inventory()
 	local craft = get_craft(pos, inventory)
-	return autocraft(inventory, craft)
+
+	for step = 1, math.floor(elapsed/craft_time) do
+		local continue = autocraft(inventory, craft)
+		if not continue then return false end
+	end
+	return true
 end
 
 local function update_autocrafter(pos)

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -52,7 +52,7 @@ end
 
 -- note, that this function assumes allready being updated to virtual items
 -- and doesn't handle recipes with stacksizes > 1
-local function on_recipe_change(pos, inventory)
+local function after_recipe_change(pos, inventory)
 	-- if we emptied the grid, there's no point in keeping it running or cached
 	if inventory:is_empty("recipe") then
 		minetest.get_node_timer(pos):stop()
@@ -81,7 +81,7 @@ local function on_recipe_change(pos, inventory)
 	start_crafter(pos)
 end
 
-local function on_inventory_change(pos, inventory)
+local function after_inventory_change(pos, inventory)
 	start_crafter(pos)
 end
 
@@ -137,7 +137,7 @@ local function update_autocrafter(pos)
 			stack:set_wear(0)
 			inv:set_stack("recipe", idx, stack)
 		end
-		on_recipe_change(pos, inv)
+		after_recipe_change(pos, inv)
 	end
 end
 
@@ -161,7 +161,7 @@ minetest.register_node("pipeworks:autocrafter", {
 			local meta = minetest.get_meta(pos)
 			local inv = meta:get_inventory()
 			local added = inv:add_item("src", stack)
-			on_inventory_change(pos, inv)
+			after_inventory_change(pos, inv)
 			return added
 		end, 
 		can_insert = function(pos, node, stack, direction)
@@ -217,10 +217,10 @@ minetest.register_node("pipeworks:autocrafter", {
 			local stack_copy = ItemStack(stack)
 			stack_copy:set_count(1)
 			inv:set_stack(listname, index, stack_copy)
-			on_recipe_change(pos, inv)
+			after_recipe_change(pos, inv)
 			return 0
 		else
-			on_inventory_change(pos, inv)
+			after_inventory_change(pos, inv)
 			return stack:get_count()
 		end
 	end,
@@ -229,10 +229,10 @@ minetest.register_node("pipeworks:autocrafter", {
 		local inv = minetest.get_meta(pos):get_inventory()
 		if listname == "recipe" then
 			inv:set_stack(listname, index, ItemStack(""))
-			on_recipe_change(pos, inv)
+			after_recipe_change(pos, inv)
 			return 0
 		else
-			on_inventory_change(pos, inv)
+			after_inventory_change(pos, inv)
 			return stack:get_count()
 		end
 	end,
@@ -243,16 +243,16 @@ minetest.register_node("pipeworks:autocrafter", {
 		stack:set_count(count)
 		if from_list == "recipe" then
 			inv:set_stack(from_list, from_index, ItemStack(""))
-			on_recipe_change(pos, inv)
+			after_recipe_change(pos, inv)
 			return 0
 		elseif to_list == "recipe" then
 			local stack_copy = ItemStack(stack)
 			stack_copy:set_count(1)
 			inv:set_stack(to_list, to_index, stack_copy)
-			on_recipe_change(pos, inv)
+			after_recipe_change(pos, inv)
 			return 0
 		else
-			on_inventory_change(pos, inv)
+			after_inventory_change(pos, inv)
 			return stack:get_count()
 		end
 	end,

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -123,6 +123,19 @@ local function after_recipe_change(pos, inventory)
 	after_inventory_change(pos)
 end
 
+-- clean out unknown items and groups, which would be handled like unknown items in the crafting grid
+-- if minetest supports query by group one day, this might replace them
+-- with a canonical version instead
+local function normalize(item_list)
+	for i = 1, #item_list do
+		local name = item_list[i]
+		if not minetest.registered_items[name] then
+			item_list[i] = ""
+		end
+	end
+	return item_list
+end
+
 local function on_output_change(pos, inventory, stack)
 	if not stack then
 		inventory:set_list("output", {})
@@ -130,7 +143,7 @@ local function on_output_change(pos, inventory, stack)
 	else
 		local input = minetest.get_craft_recipe(stack:get_name())
 		if not input.items or input.type ~= "normal" then return end
-		inventory:set_list("recipe", input.items)
+		inventory:set_list("recipe", normalize(input.items))
 		-- we'll set the output slot in after_recipe_change to the actual result of the new recipe
 	end
 	after_recipe_change(pos, inventory)

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -149,6 +149,10 @@ local function set_formspec(meta, enabled)
 			"image_button[3,2;1,1;pipeworks_button_" .. state .. ".png;" .. state .. ";;;false;pipeworks_button_interm.png]" ..
 			"list[context;src;0,3.5;8,3;]"..
 			"list[context;dst;4,0;4,3;]"..
+			default.gui_bg..
+			default.gui_bg_img..
+			default.gui_slots..
+			default.get_hotbar_bg(0,7) ..
 			"list[current_player;main;0,7;8,4;]")
 end
 

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -251,6 +251,8 @@ minetest.register_node("pipeworks:autocrafter", {
 	after_place_node = pipeworks.scan_for_tube_objects,
 	after_dig_node = function(pos)
 		pipeworks.scan_for_tube_objects(pos)
+	end,
+	on_destruct = function(pos)
 		autocrafterCache[minetest.hash_node_position(pos)] = nil
 	end,
 	allow_metadata_inventory_put = function(pos, listname, index, stack, player)

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -263,18 +263,21 @@ minetest.register_node("pipeworks:autocrafter", {
 			on_output_change(pos, inv, stack)
 			return 0
 		elseif from_list == "output" then
-			on_output_change(pos, inv, nil)
-			return 0
+			inv:set_list("output", {})
+			inv:set_list("recipe", {})
+			if to_list ~= "recipe" then
+				return 0
+			end -- else fall through to recipe list handling
 		end
 
-		if from_list == "recipe" then
-			inv:set_stack(from_list, from_index, ItemStack(""))
-		end
-		if to_list == "recipe" then
-			stack:set_count(1)
-			inv:set_stack(to_list, to_index, stack)
-		end
 		if from_list == "recipe" or to_list == "recipe" then
+			if from_list == "recipe" then
+				inv:set_stack(from_list, from_index, ItemStack(""))
+			end
+			if to_list == "recipe" then
+				stack:set_count(1)
+				inv:set_stack(to_list, to_index, stack)
+			end
 			after_recipe_change(pos, inv)
 			return 0
 		end

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -152,6 +152,12 @@ local function set_formspec(meta, enabled)
 			"list[current_player;main;0,7;8,4;]")
 end
 
+local function add_virtual_item(inv, listname, index, stack)
+	local stack_copy = ItemStack(stack)
+	stack_copy:set_count(1)
+	inv:set_stack(listname, index, stack_copy)
+end
+
 minetest.register_node("pipeworks:autocrafter", {
 	description = "Autocrafter", 
 	drawtype = "normal", 
@@ -214,9 +220,7 @@ minetest.register_node("pipeworks:autocrafter", {
 		update_autocrafter(pos)
 		local inv = minetest.get_meta(pos):get_inventory()
 		if listname == "recipe" then
-			local stack_copy = ItemStack(stack)
-			stack_copy:set_count(1)
-			inv:set_stack(listname, index, stack_copy)
+			add_virtual_item(inv, listname, index, stack)
 			after_recipe_change(pos, inv)
 			return 0
 		else
@@ -246,9 +250,7 @@ minetest.register_node("pipeworks:autocrafter", {
 			after_recipe_change(pos, inv)
 			return 0
 		elseif to_list == "recipe" then
-			local stack_copy = ItemStack(stack)
-			stack_copy:set_count(1)
-			inv:set_stack(to_list, to_index, stack_copy)
+			add_virtual_item(inv, to_list, to_index, stack)
 			after_recipe_change(pos, inv)
 			return 0
 		else

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -85,8 +85,11 @@ local function update_autocrafter(pos)
 	if meta:get_string("virtual_items") == "" then
 		meta:set_string("virtual_items", "1")
 		local inv = meta:get_inventory()
-		for _, stack in ipairs(inv:get_list("recipe")) do
+		for idx, stack in ipairs(inv:get_list("recipe")) do
 			minetest.item_drop(stack, "", pos)
+			stack:set_count(1)
+			stack:set_wear(0)
+			inv:set_stack("recipe", idx, stack)
 		end
 	end
 end

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -170,17 +170,19 @@ local function update_autocrafter(pos, meta)
 		if meta:get_string("virtual_items") == "1" then -- we are version 2
 			-- we allready dropped stuff, so lets remove the metadatasetting (we are not being called again for this node)
 			meta:set_string("virtual_items", "")
-			return
 		else -- we are version 1
 			for idx, stack in ipairs(inv:get_list("recipe")) do
-				minetest.item_drop(stack, "", pos)
-				stack:set_count(1)
-				stack:set_wear(0)
-				inv:set_stack("recipe", idx, stack)
+				if not stack:is_empty() then
+					minetest.item_drop(stack, "", pos)
+					stack:set_count(1)
+					stack:set_wear(0)
+					inv:set_stack("recipe", idx, stack)
+				end
 			end
 		end
 
 		-- update the recipe, cache, and start the crafter
+		autocrafterCache[minetest.hash_node_position(pos)] = nil
 		after_recipe_change(pos, inv)
 	end
 end

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -2,48 +2,106 @@ local autocrafterCache = {}  -- caches some recipe data to avoid to call the slo
 
 local function count_index(invlist)
 	local index = {}
-	for _, stack in ipairs(invlist) do
-		local stack_name = stack:get_name()
-		index[stack_name] = (index[stack_name] or 0) + stack:get_count()
+	for _, stack in pairs(invlist) do
+		if not stack:is_empty() then
+			local stack_name = stack:get_name()
+			index[stack_name] = (index[stack_name] or 0) + stack:get_count()
+		end
 	end
 	return index
 end
 
-local function get_cached_craft(pos)
-	local hash = minetest.hash_node_position(pos)
-	return hash, autocrafterCache[hash]
+local function get_craft(pos, inventory, hash)
+	local hash = hash or minetest.hash_node_position(pos)
+	local craft = autocrafterCache[hash]
+	if not craft then
+		if inventory:is_empty("recipe") then return nil end
+		local recipe = inventory:get_list("recipe")
+		local output, decremented_input = minetest.get_craft_result({method = "normal", width = 3, items = recipe})
+		craft = {recipe = recipe, consumption=count_index(recipe), output = output, decremented_input = decremented_input}
+		autocrafterCache[hash] = craft
+
+	end
+	-- only return crafts that have an actual result
+	if not craft.output.item:is_empty() then
+		return craft
+	end
 end
 
 -- note, that this function assumes allready being updated to virtual items
 -- and doesn't handle recipes with stacksizes > 1
 local function on_recipe_change(pos, inventory)
-	if not inventory then return end
-	local recipe = inventory:get_list("recipe")
-	if not recipe then return end
-
+	-- if we emptied the grid, there's no point in keeping it running or cached
+	if inventory:is_empty("recipe") then
+		minetest.get_node_timer(pos):stop()
+		autocrafterCache[minetest.hash_node_position(pos)] = nil
+		return
+	end
 	local recipe_changed = false
-	local hash, craft = get_cached_craft(pos)
+	local recipe = inventory:get_list("recipe")
 
-	if not craft then
-		recipe_changed = true
-	else
+	local hash = minetest.hash_node_position(pos)
+	local craft = autocrafterCache[hash]
+
+	if craft then
 		-- check if it changed
-		local cached_recipe =  craft.recipe
+		local cached_recipe = craft.recipe
 		for i = 1, 9 do
 			if recipe[i]:get_name() ~= cached_recipe[i]:get_name() then
-				recipe_changed = true
+				autocrafterCache[hash] = nil -- invalidate recipe
+				craft = nil
 				break
 			end
 		end
 	end
 
-	if recipe_changed then
-		local output, decremented_input = minetest.get_craft_result({method = "normal", width = 3, items = recipe})
-		craft = {recipe = recipe, consumption=count_index(recipe), output = output, decremented_input = decremented_input}
-		autocrafterCache[hash] = craft
+	local timer = minetest.get_node_timer(pos)
+	if not timer:is_started() then
+		timer:start(1)
+	end
+end
+
+local function on_inventory_change(pos, inventory)
+	local timer = minetest.get_node_timer(pos)
+	if not timer:is_started() then
+		timer:start(1)
+	end
+end
+
+local function autocraft(inventory, craft)
+	if not craft then return false end
+	local output_item = craft.output.item
+
+	-- check if we have enough room in dst
+	if not inventory:room_for_item("dst", output_item) then return false end
+	local consumption = craft.consumption
+	local inv_index = count_index(inventory:get_list("src"))
+	-- check if we have enough material available
+	for itemname, number in pairs(consumption) do
+		if (not inv_index[itemname]) or inv_index[itemname] < number then return false end
+	end
+	-- consume material
+	for itemname, number in pairs(consumption) do
+		for i = 1, number do -- We have to do that since remove_item does not work if count > stack_max
+			inventory:remove_item("src", ItemStack(itemname))
+		end
 	end
 
-	return craft
+	-- craft the result into the dst inventory and add any "replacements" as well
+	inventory:add_item("dst", output_item)
+	for i = 1, 9 do
+		inventory:add_item("dst", craft.decremented_input.items[i])
+	end
+	return true
+end
+
+-- returns false to stop the timer, true to continue running
+-- is started only from start_autocrafter(pos) after sanity checks and cached recipe
+local function run_autocrafter(pos, elapsed)
+	local meta = minetest.get_meta(pos)
+	local inventory = meta:get_inventory()
+	local craft = get_craft(pos, inventory)
+	return autocraft(inventory, craft)
 end
 
 local function update_autocrafter(pos)
@@ -61,51 +119,6 @@ local function update_autocrafter(pos)
 	end
 end
 
-local function autocraft(inventory, craft)
-	local output_item = craft.output.item
-	-- check if we have enough room in dst
-	if not inventory:room_for_item("dst", output_item) then return false end
-
-	local consumption = craft.consumption
-	local inv_index = count_index(inventory:get_list("src"))
-	-- check if we have enough materials available
-	for itemname, number in pairs(consumption) do
-		if (not inv_index[itemname]) or inv_index[itemname] < number then return false end
-	end
-
-	-- consume materials
-	for itemname, number in pairs(consumption) do
-		for i = 1, number do -- We have to do that since remove_item does not work if count > stack_max
-			inventory:remove_item("src", ItemStack(itemname))
-		end
-	end
-
-	-- craft the result into the dst inventory and add any "replacements" as well
-	inventory:add_item("dst", output_item)
-	for i = 1, 9 do
-		inventory:add_item("dst", craft.decremented_input.items[i])
-	end
-	return true
-end
-
-local function run_autocrafter(inventory, pos)
-	if not inventory then return end
-	local recipe = inventory:get_list("recipe")
-	if not recipe then return end
-
-	local _, craft = get_cached_craft(pos)
-	if craft == nil then
-		update_autocrafter(pos) -- only does some unnecessary calls for "old" autocrafters
-		craft = on_recipe_change(pos, inventory)
-	end
-
-	-- skip crafts that have no output
-	local output_item = craft.output.item
-	if output_item:is_empty() then return end
-
-	autocraft(inventory, craft)
-end
-
 minetest.register_node("pipeworks:autocrafter", {
 	description = "Autocrafter", 
 	drawtype = "normal", 
@@ -114,7 +127,9 @@ minetest.register_node("pipeworks:autocrafter", {
 	tube = {insert_object = function(pos, node, stack, direction)
 			local meta = minetest.get_meta(pos)
 			local inv = meta:get_inventory()
-			return inv:add_item("src", stack)
+			local added = inv:add_item("src", stack)
+			on_inventory_change(pos, inv)
+			return added
 		end, 
 		can_insert = function(pos, node, stack, direction)
 			local meta = minetest.get_meta(pos)
@@ -162,6 +177,7 @@ minetest.register_node("pipeworks:autocrafter", {
 			on_recipe_change(pos, inv)
 			return 0
 		else
+			on_inventory_change(pos, inv)
 			return stack:get_count()
 		end
 	end,
@@ -173,6 +189,7 @@ minetest.register_node("pipeworks:autocrafter", {
 			on_recipe_change(pos, inv)
 			return 0
 		else
+			on_inventory_change(pos, inv)
 			return stack:get_count()
 		end
 	end,
@@ -192,15 +209,9 @@ minetest.register_node("pipeworks:autocrafter", {
 			on_recipe_change(pos, inv)
 			return 0
 		else
+			on_inventory_change(pos, inv)
 			return stack:get_count()
 		end
 	end,
-})
-
-minetest.register_abm({nodenames = {"pipeworks:autocrafter"}, interval = 1, chance = 1, 
-			action = function(pos, node)
-				local meta = minetest.get_meta(pos)
-				local inv = meta:get_inventory()
-				run_autocrafter(inv, pos)
-			end
+	on_timer = run_autocrafter
 })

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -39,7 +39,7 @@ local function on_recipe_change(pos, inventory)
 
 	if recipe_changed then
 		local output, decremented_input = minetest.get_craft_result({method = "normal", width = 3, items = recipe})
-		craft = {recipe = recipe, output = output, decremented_input = decremented_input}
+		craft = {recipe = recipe, consumption=count_index(recipe), output = output, decremented_input = decremented_input}
 		autocrafterCache[hash] = craft
 	end
 
@@ -75,15 +75,7 @@ local function autocraft(inventory, pos)
 	local output_item = craft.output.item
 	if output_item:is_empty() or not inventory:room_for_item("dst", output_item) then return end
 
-	-- determine how much we have to consume each craft
-	local consumption = {}
-	for _, item in ipairs(recipe) do
-		if item and not item:is_empty() then
-			local item_name = item:get_name()
-			consumption[item_name] = (consumption[item_name] or 0) + 1
-		end
-	end
-
+	local consumption = craft.consumption
 	local inv_index = count_index(inventory:get_list("src"))
 	-- check if we have enough materials available
 	for itemname, number in pairs(consumption) do

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -291,8 +291,7 @@ minetest.register_node("pipeworks:autocrafter", {
 			on_output_change(pos, inv, stack)
 			return 0
 		elseif from_list == "output" then
-			inv:set_list("output", {})
-			inv:set_list("recipe", {})
+			on_output_change(pos, inv, nil)
 			if to_list ~= "recipe" then
 				return 0
 			end -- else fall through to recipe list handling


### PR DESCRIPTION
* optimize code execution and caching; especially move from abm's to stopable nodetimers, so autocrafters won't waste cpu anymore when idling
* allow virtual items to be moved around in the crafting grid
* let it "catch up" on crafts for missed time in loaded chunks (this might be removed easily again in the future if it turns out to be "too much")
* add an enable/disable button to the autocrafter
* add useful infotexts
* improve updating behavior from earlier autocrafter versions
* formspec styling
* adds a crafting preview
* allow (to some degree) setting and emptying the crafting grid via the preview field.

This last feature is still affected by minetest/minetest#2222 so expect getting the crafting grid set to something different when putting a result into the output/preview field for a few cases. It has to be fixed in the engine and should not be abuseable as far as i can tell and test, just occasionally unexpected.