### PR TITLE
Make sorting tubes not drop elements if all outputs filtering for a spec...

### DIFF
--- a/filter-injector.lua
+++ b/filter-injector.lua
@@ -78,7 +78,7 @@ local function grabAndFire(data,slotseq_mode,filtmeta,frominv,frominvname,frompo
 				local count
 				if all then
 					count = math.min(stack:get_count(), doRemove)
-					if filterfor.count > 1 then
+					if filterfor.count and filterfor.count > 1 then
 						count = math.min(filterfor.count, count)
 					end
 				else

--- a/sorting_tubes.lua
+++ b/sorting_tubes.lua
@@ -52,22 +52,29 @@ if pipeworks.enable_mese_tube then
 						 local inv = meta:get_inventory()
 						 local name = stack:get_name()
 						 for i, vect in ipairs(pipeworks.meseadjlist) do
-							 if meta:get_int("l"..i.."s") == 1 then
-								 local invname = "line"..i
-								 local is_empty = true
-								 for _, st in ipairs(inv:get_list(invname)) do
-									 if not st:is_empty() then
-										 is_empty = false
-										 if st:get_name() == name then
-											 foundn = foundn + 1
-											 found[foundn] = vect
-										 end
-									 end
-								 end
-								 if is_empty then
-									 tbln = tbln + 1
-									 tbl[tbln] = vect
-								 end
+							local npos = vector.add(pos, vect)
+							local node = minetest.get_node(npos)
+							local reg_node = minetest.registered_nodes[node.name]
+							if meta:get_int("l"..i.."s") == 1 and reg_node then
+								local tube_def = reg_node.tube
+								if not tube_def or not tube_def.can_insert or
+								tube_def.can_insert(npos, node, stack, vect) then
+									local invname = "line"..i
+									local is_empty = true
+									for _, st in ipairs(inv:get_list(invname)) do
+										if not st:is_empty() then
+											is_empty = false
+											if st:get_name() == name then
+												foundn = foundn + 1
+												found[foundn] = vect
+											end
+										end
+									end
+									if is_empty then
+										tbln = tbln + 1
+										tbl[tbln] = vect
+									end
+								end
 							 end
 						 end
 						 return (foundn > 0) and found or tbl


### PR DESCRIPTION
...ific element are filled.

Send them to some other open (empty) port instead.

Also fix crash pointed out by @t4im.