### PR TITLE
teleport_tube.lua recipe change

### DIFF
--- a/teleport_tube.lua
+++ b/teleport_tube.lua
@@ -225,7 +225,7 @@ minetest.register_craft( {
 	output = "pipeworks:teleport_tube_1 2",
 	recipe = {
 	        { "homedecor:plastic_sheeting", "homedecor:plastic_sheeting", "homedecor:plastic_sheeting" },
-	        { "default:desert_stone", "default:mese_block", "default:desert_stone" },
+	        { "default:desert_stone", "default:mese", "default:desert_stone" },
 	        { "homedecor:plastic_sheeting", "homedecor:plastic_sheeting", "homedecor:plastic_sheeting" }
 	},
 })


### PR DESCRIPTION
The default mese block has been changed to default:mese, so a change of the recipe of the teleport_tube_1 had to be made