### PR TITLE
Fix sand pipes

### DIFF
--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -238,24 +238,24 @@ local function upgrade_autocrafter(pos, meta)
 end
 
 minetest.register_node("pipeworks:autocrafter", {
-	description = "Autocrafter", 
-	drawtype = "normal", 
-	tiles = {"pipeworks_autocrafter.png"}, 
-	groups = {snappy = 3, tubedevice = 1, tubedevice_receiver = 1}, 
+	description = "Autocrafter",
+	drawtype = "normal",
+	tiles = {"pipeworks_autocrafter.png"},
+	groups = {snappy = 3, tubedevice = 1, tubedevice_receiver = 1},
 	tube = {insert_object = function(pos, node, stack, direction)
 			local meta = minetest.get_meta(pos)
 			local inv = meta:get_inventory()
 			local added = inv:add_item("src", stack)
 			after_inventory_change(pos)
 			return added
-		end, 
+		end,
 		can_insert = function(pos, node, stack, direction)
 			local meta = minetest.get_meta(pos)
 			local inv = meta:get_inventory()
 			return inv:room_for_item("src", stack)
-		end, 
-		input_inventory = "dst", 
-		connect_sides = {left = 1, right = 1, front = 1, back = 1, top = 1, bottom = 1}}, 
+		end,
+		input_inventory = "dst",
+		connect_sides = {left = 1, right = 1, front = 1, back = 1, top = 1, bottom = 1}},
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 		local inv = meta:get_inventory()
@@ -282,7 +282,7 @@ minetest.register_node("pipeworks:autocrafter", {
 		local meta = minetest.get_meta(pos)
 		local inv = meta:get_inventory()
 		return (inv:is_empty("src") and inv:is_empty("dst"))
-	end, 
+	end,
 	after_place_node = pipeworks.scan_for_tube_objects,
 	after_dig_node = function(pos)
 		pipeworks.scan_for_tube_objects(pos)

--- a/devices.lua
+++ b/devices.lua
@@ -67,10 +67,10 @@ for s in ipairs(states) do
 		drop = "pipeworks:pump_off",
 		mesecons = {effector = {
 			action_on = function (pos, node)
-				minetest.add_node(pos,{name="pipeworks:pump_on", param2 = node.param2}) 
+				minetest.add_node(pos,{name="pipeworks:pump_on", param2 = node.param2})
 			end,
 			action_off = function (pos, node)
-				minetest.add_node(pos,{name="pipeworks:pump_off", param2 = node.param2}) 
+				minetest.add_node(pos,{name="pipeworks:pump_off", param2 = node.param2})
 			end
 		}},
 		on_punch = function(pos, node, puncher)
@@ -78,7 +78,7 @@ for s in ipairs(states) do
 			minetest.add_node(pos, { name = "pipeworks:pump_"..states[3-s], param2 = fdir })
 		end
 	})
-	
+
 	minetest.register_node("pipeworks:valve_"..states[s].."_empty", {
 		description = "Valve",
 		drawtype = "mesh",
@@ -107,10 +107,10 @@ for s in ipairs(states) do
 	drop = "pipeworks:valve_off_empty",
 		mesecons = {effector = {
 			action_on = function (pos, node)
-				minetest.add_node(pos,{name="pipeworks:valve_on_empty", param2 = node.param2}) 
+				minetest.add_node(pos,{name="pipeworks:valve_on_empty", param2 = node.param2})
 			end,
 			action_off = function (pos, node)
-				minetest.add_node(pos,{name="pipeworks:valve_off_empty", param2 = node.param2}) 
+				minetest.add_node(pos,{name="pipeworks:valve_off_empty", param2 = node.param2})
 			end
 		}},
 		on_punch = function(pos, node, puncher)
@@ -148,10 +148,10 @@ minetest.register_node("pipeworks:valve_on_loaded", {
 	drop = "pipeworks:valve_off_empty",
 	mesecons = {effector = {
 		action_on = function (pos, node)
-			minetest.add_node(pos,{name="pipeworks:valve_on_empty", param2 = node.param2}) 
+			minetest.add_node(pos,{name="pipeworks:valve_on_empty", param2 = node.param2})
 		end,
 		action_off = function (pos, node)
-			minetest.add_node(pos,{name="pipeworks:valve_off_empty", param2 = node.param2}) 
+			minetest.add_node(pos,{name="pipeworks:valve_off_empty", param2 = node.param2})
 		end
 	}},
 	on_punch = function(pos, node, puncher)
@@ -284,7 +284,7 @@ minetest.register_node("pipeworks:entry_panel_empty", {
 	collision_box = panel_cbox,
 	on_place = function(itemstack, placer, pointed_thing)
 		local playername = placer:get_player_name()
-		if not minetest.is_protected(pointed_thing.under, playername) 
+		if not minetest.is_protected(pointed_thing.under, playername)
 		   and not minetest.is_protected(pointed_thing.above, playername) then
 			local node = minetest.get_node(pointed_thing.under)
 
@@ -376,7 +376,7 @@ minetest.register_node("pipeworks:flow_sensor_empty", {
 	end,
 	on_construct = function(pos)
 		if mesecon then
-			mesecon.receptor_off(pos, rules) 
+			mesecon.receptor_off(pos, rules)
 		end
 	end,
 	selection_box = {
@@ -415,7 +415,7 @@ minetest.register_node("pipeworks:flow_sensor_loaded", {
 	end,
 	on_construct = function(pos)
 		if mesecon then
-			mesecon.receptor_on(pos, rules) 
+			mesecon.receptor_on(pos, rules)
 		end
 	end,
 	selection_box = {
@@ -522,7 +522,7 @@ minetest.register_node("pipeworks:fountainhead", {
 	end,
 	on_construct = function(pos)
 		if mesecon then
-			mesecon.receptor_on(pos, rules) 
+			mesecon.receptor_on(pos, rules)
 		end
 	end,
 	selection_box = {
@@ -553,7 +553,7 @@ minetest.register_node("pipeworks:fountainhead_pouring", {
 	end,
 	on_construct = function(pos)
 		if mesecon then
-			mesecon.receptor_on(pos, rules) 
+			mesecon.receptor_on(pos, rules)
 		end
 	end,
 	selection_box = {

--- a/flowing_logic.lua
+++ b/flowing_logic.lua
@@ -46,8 +46,8 @@ pipeworks.check_for_inflows = function(pos,node)
 			source = {x=coords[i].x,y=coords[i].y,z=coords[i].z}
 		end
 	end
-	if newnode then 
-		minetest.add_node(pos,{name=newnode, param2 = node.param2}) 
+	if newnode then
+		minetest.add_node(pos,{name=newnode, param2 = node.param2})
 		minetest.get_meta(pos):set_string("source",minetest.pos_to_string(source))
 	end
 end
@@ -61,15 +61,15 @@ pipeworks.check_sources = function(pos,node)
 		newnode = string.gsub(node.name,"loaded","empty")
 	end
 
-	if newnode then 
-		minetest.add_node(pos,{name=newnode, param2 = node.param2}) 
+	if newnode then
+		minetest.add_node(pos,{name=newnode, param2 = node.param2})
 		minetest.get_meta(pos):set_string("source","")
 	end
 end
 
 pipeworks.spigot_check = function(pos, node)
 	local belowname = minetest.get_node({x=pos.x,y=pos.y-1,z=pos.z}).name
-	if belowname and (belowname == "air" or belowname == "default:water_flowing" or belowname == "default:water_source") then 
+	if belowname and (belowname == "air" or belowname == "default:water_flowing" or belowname == "default:water_source") then
 		local spigotname = minetest.get_node(pos).name
 		local fdir=node.param2
 		local check = {
@@ -99,7 +99,7 @@ end
 
 pipeworks.fountainhead_check = function(pos, node)
 	local abovename = minetest.get_node({x=pos.x,y=pos.y+1,z=pos.z}).name
-	if abovename and (abovename == "air" or abovename == "default:water_flowing" or abovename == "default:water_source") then 
+	if abovename and (abovename == "air" or abovename == "default:water_flowing" or abovename == "default:water_source") then
 		local fountainhead_name = minetest.get_node(pos).name
 		local near_node = minetest.get_node({x=pos.x,y=pos.y-1,z=pos.z})
 		if near_node and string.find(near_node.name, "_loaded") then

--- a/item_transport.lua
+++ b/item_transport.lua
@@ -78,7 +78,7 @@ local function go_next(pos, velocity, stack)
 	if not next_positions[1] then
 		return false, nil
 	end
-	
+
 	local n = (cmeta:get_int("tubedir") % (#next_positions)) + 1
 	if pipeworks.enable_cyclic_mode then
 		cmeta:set_int("tubedir", n)
@@ -183,7 +183,7 @@ luaentity.register_entity("pipeworks:tubed_item", {
 		self.itemstring = itemstring
 		self.item_entity = self:add_attached_entity("pipeworks:tubed_item", itemstring)
 	end,
-	
+
 	set_color = function(self, color)
 		if self.color == color then
 			return
@@ -205,13 +205,13 @@ luaentity.register_entity("pipeworks:tubed_item", {
 			self.start_pos = vector.round(pos)
 			self:setpos(pos)
 		end
-		
+
 		local pos = self:getpos()
 		local stack = ItemStack(self.itemstring)
 		local drop_pos
-		
+
 		local velocity = self:getvelocity()
-		
+
 		local moved = false
 		local speed = math.abs(velocity.x + velocity.y + velocity.z)
 		if speed == 0 then
@@ -219,12 +219,12 @@ luaentity.register_entity("pipeworks:tubed_item", {
 			moved = true
 		end
 		local vel = {x = velocity.x / speed, y = velocity.y / speed, z = velocity.z / speed, speed = speed}
-		
+
 		if vector.distance(pos, self.start_pos) >= 1 then
 			self.start_pos = vector.add(self.start_pos, vel)
 			moved = true
 		end
-		
+
 		minetest.load_position(self.start_pos)
 		local node = minetest.get_node(self.start_pos)
 		if moved and minetest.get_item_group(node.name, "tubedevice_receiver") == 1 then
@@ -243,18 +243,18 @@ luaentity.register_entity("pipeworks:tubed_item", {
 			self:set_item(leftover:to_string())
 			return
 		end
-		
+
 		if moved then
 			local found_next, new_velocity = go_next(self.start_pos, velocity, stack) -- todo: color
 			if not found_next then
 				drop_pos = minetest.find_node_near(vector.add(self.start_pos, velocity), 1, "air")
-				if drop_pos then 
+				if drop_pos then
 					minetest.item_drop(stack, "", drop_pos)
 					self:remove()
 					return
 				end
 			end
-			
+
 			if new_velocity and not vector.equals(velocity, new_velocity) then
 				self:setpos(self.start_pos)
 				self:setvelocity(new_velocity)

--- a/legacy.lua
+++ b/legacy.lua
@@ -1,5 +1,5 @@
 
-if not minetest.get_modpath("auto_tree_tap") and 
+if not minetest.get_modpath("auto_tree_tap") and
   minetest.get_modpath("technic") then
 
 	minetest.register_abm({
@@ -37,10 +37,10 @@ if not minetest.get_modpath("auto_tree_tap") and
 		after_place_node = function (pos, placer)
 			pipeworks.scan_for_tube_objects(pos, placer)
 			local placer_pos = placer:getpos()
-		
+
 			--correct for the player's height
 			if placer:is_player() then placer_pos.y = placer_pos.y + 1.5 end
-		
+
 			--correct for 6d facedir
 			if placer_pos then
 				local dir = {

--- a/luaentity.lua
+++ b/luaentity.lua
@@ -194,7 +194,7 @@ local entitydef_default = {
 		end
 	end,
 	getvelocity = function(self)
-		return vector.new(self._velocity)	
+		return vector.new(self._velocity)
 	end,
 	setvelocity = function(self, velocity)
 		self._velocity = vector.new(velocity)
@@ -272,7 +272,7 @@ function luaentity.add_entity(pos, name)
 		_acceleration = {x = 0, y = 0, z = 0},
 		_attached_entities = {},
 	}
-	
+
 	local prototype = luaentity.registered_entities[name]
 	setmetatable(entity, prototype) -- Default to prototype for other methods
 	luaentity.entities[index] = entity

--- a/models.lua
+++ b/models.lua
@@ -34,7 +34,7 @@ pipeworks.tube_frontstub = {
 
 pipeworks.tube_backstub = {
 	{ -9/64, -9/64, -9/64,   9/64, 9/64, 32/64 },	-- tube segment against -Z face
-} 
+}
 
 pipeworks.tube_boxes = {pipeworks.tube_leftstub, pipeworks.tube_rightstub, pipeworks.tube_bottomstub, pipeworks.tube_topstub, pipeworks.tube_frontstub, pipeworks.tube_backstub}
 

--- a/pipes.lua
+++ b/pipes.lua
@@ -9,7 +9,7 @@ local vti = {4, 3, 2, 1, 6, 5}
 local cconnects = {{}, {1}, {1, 2}, {1, 3}, {1, 3, 5}, {1, 2, 3}, {1, 2, 3, 5}, {1, 2, 3, 4}, {1, 2, 3, 4, 5}, {1, 2, 3, 4, 5, 6}}
 for index, connects in ipairs(cconnects) do
 	local outsel = {}
-	
+
 	local jx = 0
 	local jy = 0
 	local jz = 0
@@ -28,7 +28,7 @@ for index, connects in ipairs(cconnects) do
 		local v = connects[1]
 		v = v-1 + 2*(v%2) -- Opposite side
 	end
-	
+
 	local pgroups = {snappy = 3, pipe = 1, not_in_creative_inventory = 1}
 	local pipedesc = "Pipe segement".." "..dump(connects).."... You hacker, you."
 	local image = nil
@@ -38,11 +38,11 @@ for index, connects in ipairs(cconnects) do
 		pipedesc = "Pipe segment"
 		image = "pipeworks_pipe_inv.png"
 	end
-	
+
 	local outimg_e = { "pipeworks_pipe_plain.png" }
 	local outimg_l = { "pipeworks_pipe_plain.png" }
 
-	if index == 3 then 
+	if index == 3 then
 		outimg_e = { "pipeworks_pipe_3_empty.png" }
 		outimg_l = { "pipeworks_pipe_3_loaded.png" }
 	end
@@ -82,7 +82,7 @@ for index, connects in ipairs(cconnects) do
 			pipeworks.scan_for_pipe_objects(pos)
 		end
 	})
-	
+
 	local pgroups = {snappy = 3, pipe = 1, not_in_creative_inventory = 1}
 
 	minetest.register_node("pipeworks:pipe_"..index.."_loaded", {
@@ -112,7 +112,7 @@ for index, connects in ipairs(cconnects) do
 			pipeworks.scan_for_pipe_objects(pos)
 		end
 	})
-	
+
 	table.insert(pipes_empty_nodenames, "pipeworks:pipe_"..index.."_empty")
 	table.insert(pipes_full_nodenames,  "pipeworks:pipe_"..index.."_loaded")
 end
@@ -206,7 +206,7 @@ minetest.register_abm({
 	nodenames = {"pipeworks:spigot","pipeworks:spigot_pouring"},
 	interval = 1,
 	chance = 1,
-	action = function(pos, node, active_object_count, active_object_count_wider) 
+	action = function(pos, node, active_object_count, active_object_count_wider)
 		pipeworks.spigot_check(pos,node)
 	end
 })
@@ -215,7 +215,7 @@ minetest.register_abm({
 	nodenames = {"pipeworks:fountainhead","pipeworks:fountainhead_pouring"},
 	interval = 1,
 	chance = 1,
-	action = function(pos, node, active_object_count, active_object_count_wider) 
+	action = function(pos, node, active_object_count, active_object_count_wider)
 		pipeworks.fountainhead_check(pos,node)
 	end
 })

--- a/teleport_tube.lua
+++ b/teleport_tube.lua
@@ -173,7 +173,7 @@ pipeworks.register_tube("pipeworks:teleport_tube", {
 					if mode == ":" then
 						minetest.chat_send_player(sender_name, "Sorry, channel '"..new_channel.."' is reserved for exclusive use by "..name)
 						return
-				
+
 					--channels starting with '[name];' can be used by other players, but cannot be received from
 					elseif mode == ";" and (fields.cr1 or (can_receive ~= 0 and not fields.cr0)) then
 						minetest.chat_send_player(sender_name, "Sorry, receiving from channel '"..new_channel.."' is reserved for "..name)

--- a/trashcan.lua
+++ b/trashcan.lua
@@ -1,6 +1,6 @@
 minetest.register_node("pipeworks:trashcan", {
-	description = "Trash Can", 
-	drawtype = "normal", 
+	description = "Trash Can",
+	drawtype = "normal",
 	tiles = {
 		"pipeworks_trashcan_bottom.png",
 		"pipeworks_trashcan_bottom.png",
@@ -8,15 +8,15 @@ minetest.register_node("pipeworks:trashcan", {
 		"pipeworks_trashcan_side.png",
 		"pipeworks_trashcan_side.png",
 		"pipeworks_trashcan_side.png",
-	}, 
-	groups = {snappy = 3, tubedevice = 1, tubedevice_receiver = 1}, 
+	},
+	groups = {snappy = 3, tubedevice = 1, tubedevice_receiver = 1},
 	tube = {
 		insert_object = function(pos, node, stack, direction)
 			return ItemStack("")
 		end,
 		connect_sides = {left = 1, right = 1, front = 1, back = 1, top = 1, bottom = 1},
 		priority = 1, -- Lower than anything else
-	}, 
+	},
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 		meta:set_string("formspec",
@@ -31,7 +31,7 @@ minetest.register_node("pipeworks:trashcan", {
 				"list[current_player;main;0,3;8,4;]")
 		meta:set_string("infotext", "Trash Can")
 		meta:get_inventory():set_size("trash", 1)
-	end, 
+	end,
 	after_place_node = pipeworks.after_place,
 	after_dig_node = pipeworks.after_dig,
 	on_metadata_inventory_put = function(pos, listname, index, stack, player)

--- a/tube_registration.lua
+++ b/tube_registration.lua
@@ -38,11 +38,11 @@ local register_one_tube = function(name, tname, dropname, desc, plain, noctrs, e
 	local outboxes = {}
 	local outsel = {}
 	local outimgs = {}
-	
+
 	for i = 1, 6 do
 		outimgs[vti[i]] = plain[i]
 	end
-	
+
 	for _, v in ipairs(connects) do
 		table.extend(outboxes, pipeworks.tube_boxes[v])
 		table.insert(outsel, pipeworks.tube_selectboxes[v])
@@ -73,10 +73,10 @@ local register_one_tube = function(name, tname, dropname, desc, plain, noctrs, e
 		outsel = { -24/64, -10/64, -10/64, 24/64, 10/64, 10/64 }
 		wscale = {x = 1, y = 1, z = 0.01}
 	end
-	
+
 	local rname = string.format("%s_%s", name, tname)
 	table.insert(tubenodes, rname)
-	
+
 	local nodedef = {
 		description = tubedesc,
 		drawtype = "nodebox",
@@ -112,7 +112,7 @@ local register_one_tube = function(name, tname, dropname, desc, plain, noctrs, e
 	if style == "6d" then
 		nodedef.paramtype2 = "facedir"
 	end
-	
+
 	if special == nil then special = {} end
 
 	for key, value in pairs(special) do

--- a/vacuum_tubes.lua
+++ b/vacuum_tubes.lua
@@ -1,12 +1,100 @@
+if not pipeworks.enable_sand_tube
+and not pipeworks.enable_mese_sand_tube then
+	return
+end
+
+-- radius of the not adjustable tube
+local radius_normal = 2
+
+-- maximum radius of the adjustable tube
+local radius_max = 8
+
+-- every <update_interval> seconds unloaded vacuum tubes are searched
+local update_interval = 4
+
+-- it takes <vacuuming_speed> seconds until a fresh item gets picked up
+local vacuuming_speed = 0.5
+
+
+-- remembers known tube positions and their radians
+local known_vacuumings = {}
+local function get_vacuuming(pos)
+	if not known_vacuumings[pos.z] then
+		return false
+	end
+	if not known_vacuumings[pos.z][pos.y] then
+		return false
+	end
+	return known_vacuumings[pos.z][pos.y][pos.x] or false
+end
+
+-- vacuum function is used if a sand pipe becomes constructed
+local tube_inject_item = pipeworks.tube_inject_item
+local get_objects_inside_radius = minetest.get_objects_inside_radius
+local function vacuum(pos, radius)
+	for _, object in pairs(get_objects_inside_radius(pos, radius)) do
+		local lua_entity = object:get_luaentity()
+		if not object:is_player()
+		and lua_entity
+		and lua_entity.name == "__builtin:item" then
+			local obj_pos = object:getpos()
+			local x1, y1, z1 = pos.x, pos.y, pos.z
+			local x2, y2, z2 = obj_pos.x, obj_pos.y, obj_pos.z
+
+			if  x1 - radius <= x2 and x2 <= x1 + radius
+			and y1 - radius <= y2 and y2 <= y1 + radius
+			and z1 - radius <= z2 and z2 <= z1 + radius then
+				if lua_entity.itemstring ~= "" then
+					tube_inject_item(pos, pos, vector.new(0, 0, 0), lua_entity.itemstring)
+					lua_entity.itemstring = ""
+				end
+				object:remove()
+			end
+		end
+	end
+end
+
+-- begins knowing a tube
+local function set_vacuuming(pos, r)
+	known_vacuumings[pos.z] = known_vacuumings[pos.z] or {}
+	known_vacuumings[pos.z][pos.y] = known_vacuumings[pos.z][pos.y] or {}
+	known_vacuumings[pos.z][pos.y][pos.x] = r
+	vacuum(pos, r+0.5)
+end
+
+-- a known tube disappeared
+local function remove_vacuuming(pos)
+	known_vacuumings[pos.z][pos.y][pos.x] = nil
+	if next(known_vacuumings[pos.z][pos.y]) then
+		return
+	end
+	known_vacuumings[pos.z][pos.y] = nil
+	if next(known_vacuumings[pos.z]) then
+		return
+	end
+	known_vacuumings[pos.z] = nil
+end
+
+
 if pipeworks.enable_sand_tube then
 	pipeworks.register_tube("pipeworks:sand_tube", {
-			description = "Vacuuming Pneumatic Tube Segment",
-			inventory_image = "pipeworks_sand_tube_inv.png",
-			short = "pipeworks_sand_tube_short.png",
-			noctr = { "pipeworks_sand_tube_noctr.png" },
-			plain = { "pipeworks_sand_tube_plain.png" },
-			ends = { "pipeworks_sand_tube_end.png" },
-			node_def = { groups = {vacuum_tube = 1}},
+		description = "Vacuuming Pneumatic Tube Segment",
+		inventory_image = "pipeworks_sand_tube_inv.png",
+		short = "pipeworks_sand_tube_short.png",
+		noctr = { "pipeworks_sand_tube_noctr.png" },
+		plain = { "pipeworks_sand_tube_plain.png" },
+		ends = { "pipeworks_sand_tube_end.png" },
+		node_def = {
+			groups = {vacuum_tube = 1},
+			on_construct = function(pos)
+				set_vacuuming(pos, radius_normal)
+			end,
+			on_destruct = function(pos)
+				if get_vacuuming(pos) then
+					remove_vacuuming(pos)
+				end
+			end,
+		},
 	})
 
 	minetest.register_craft( {
@@ -28,36 +116,45 @@ end
 
 if pipeworks.enable_mese_sand_tube then
 	pipeworks.register_tube("pipeworks:mese_sand_tube", {
-			description = "Adjustable Vacuuming Pneumatic Tube Segment",
-			inventory_image = "pipeworks_mese_sand_tube_inv.png",
-			short = "pipeworks_mese_sand_tube_short.png",
-			noctr = { "pipeworks_mese_sand_tube_noctr.png" },
-			plain = { "pipeworks_mese_sand_tube_plain.png" },
-			ends = { "pipeworks_mese_sand_tube_end.png" },
-			node_def = {
-				groups = {vacuum_tube = 1},
-				on_construct = function(pos)
-					local meta = minetest.get_meta(pos)
-					meta:set_int("dist", 0)
-					meta:set_string("formspec", "size[2.1,0.8]"..
-							"image[0,0;1,1;pipeworks_mese_sand_tube_inv.png]"..
-							"field[1.3,0.4;1,1;dist;radius;${dist}]"..
-							default.gui_bg..
-							default.gui_bg_img)
-					meta:set_string("infotext", "Adjustable Vacuuming Pneumatic Tube Segment")
-				end,
-				on_receive_fields = function(pos,formname,fields,sender)
-					if not pipeworks.may_configure(pos, sender) then return end
-					local meta = minetest.get_meta(pos)
-					local dist = tonumber(fields.dist)
-					if dist then
-						dist = math.max(0, dist)
-						dist = math.min(8, dist)
-						meta:set_int("dist", dist)
-						meta:set_string("infotext", ("Adjustable Vacuuming Pneumatic Tube Segment (%dm)"):format(dist))
-					end
-				end,
-			},
+		description = "Adjustable Vacuuming Pneumatic Tube Segment",
+		inventory_image = "pipeworks_mese_sand_tube_inv.png",
+		short = "pipeworks_mese_sand_tube_short.png",
+		noctr = { "pipeworks_mese_sand_tube_noctr.png" },
+		plain = { "pipeworks_mese_sand_tube_plain.png" },
+		ends = { "pipeworks_mese_sand_tube_end.png" },
+		node_def = {
+			groups = {vacuum_tube = 1},
+			on_construct = function(pos)
+				set_vacuuming(pos, 0)
+				local meta = minetest.get_meta(pos)
+				meta:set_int("dist", 0)
+				meta:set_string("formspec", "size[2.1,0.8]"..
+					"image[0,0;1,1;pipeworks_mese_sand_tube_inv.png]"..
+					"field[1.3,0.4;1,1;dist;radius;${dist}]"..
+					default.gui_bg..
+					default.gui_bg_img)
+				meta:set_string("infotext", "Adjustable Vacuuming Pneumatic Tube Segment")
+			end,
+			on_receive_fields = function(pos,_,fields,sender)
+				if not pipeworks.may_configure(pos, sender) then
+					return
+				end
+				local dist = tonumber(fields.dist)
+				if not dist then
+					return
+				end
+				dist = math.min(radius_max, math.max(0, dist))
+				set_vacuuming(pos, dist)
+				local meta = minetest.get_meta(pos)
+				meta:set_int("dist", dist)
+				meta:set_string("infotext", ("Adjustable Vacuuming Pneumatic Tube Segment (%dm)"):format(dist))
+			end,
+			on_destruct = function(pos)
+				if get_vacuuming(pos) then
+					remove_vacuuming(pos)
+				end
+			end,
+		},
 	})
 
 	minetest.register_craft( {
@@ -82,41 +179,93 @@ if pipeworks.enable_mese_sand_tube then
 	})
 end
 
-local sqrt_3 = math.sqrt(3)
-local tube_inject_item = pipeworks.tube_inject_item
-local get_objects_inside_radius = minetest.get_objects_inside_radius
-local function vacuum(pos, radius)
-	radius = radius + 0.5
-	for _, object in pairs(get_objects_inside_radius(pos, sqrt_3 * radius)) do
-		local lua_entity = object:get_luaentity()
-		if not object:is_player() and lua_entity and lua_entity.name == "__builtin:item" then
-			local obj_pos = object:getpos()
-			local x1, y1, z1 = pos.x, pos.y, pos.z
-			local x2, y2, z2 = obj_pos.x, obj_pos.y, obj_pos.z
+minetest.register_abm({
+	nodenames = {"group:vacuum_tube"},
+	interval = update_interval,
+	chance = 1,
+	label = "Vacuum tubes",
+	action = function(pos, node, active_object_count, active_object_count_wider)
+		if get_vacuuming(pos) then
+			return
+		end
+		local radius
+		if string.find(node.name, "pipeworks:sand_tube") then
+			radius = radius_normal
+		elseif string.find(node.name, "pipeworks:mese_sand_tube") then
+			radius = tonumber(minetest.get_meta(pos):get_int("dist")) or 0
+		else
+			minetest.log("error", "[pipeworks] unknown vacuum pipe node: "..node.name)
+			return
+		end
+		set_vacuuming(pos, radius)
+	end
+})
 
-			if  x1 - radius <= x2 and x2 <= x1 + radius
-			and y1 - radius <= y2 and y2 <= y1 + radius
-			and z1 - radius <= z2 and z2 <= z1 + radius then
-				if lua_entity.itemstring ~= "" then
-					tube_inject_item(pos, pos, vector.new(0, 0, 0), lua_entity.itemstring)
-					lua_entity.itemstring = ""
+-- searches sand tubes near the object and puts it into it if one is found
+local maxradius = radius_max
+local function get_vacuumed(obj)
+	local lua_entity = obj:get_luaentity()
+	if not lua_entity or lua_entity.itemstring == "" then
+		return false
+	end
+	local pos = obj:getpos()
+	for z = math.floor(pos.z-maxradius), math.ceil(pos.z+maxradius) do
+		if known_vacuumings[z] then
+			for y = math.floor(pos.y-maxradius), math.ceil(pos.y+maxradius) do
+				if known_vacuumings[z][y] then
+					for x = math.floor(pos.x-maxradius), math.ceil(pos.x+maxradius) do
+						local r = known_vacuumings[z][y][x]
+						if r then
+							local tpos = {x=x, y=y, z=z}
+							local objtotube = vector.subtract(tpos, pos)
+							if math.max(math.abs(objtotube.x), math.abs(objtotube.y), math.abs(objtotube.z)) <= r
+							and vector.length(objtotube) <= r then
+								tube_inject_item(tpos, tpos, vector.new(0, 0, 0), lua_entity.itemstring)
+								lua_entity.itemstring = ""
+								obj:remove()
+								return true
+							end
+						end
+					end
 				end
-				object:remove()
 			end
 		end
 	end
+	return false
 end
 
-minetest.register_abm({nodenames = {"group:vacuum_tube"},
-			interval = 1,
-			chance = 1,
-			label = "Vacuum tubes",
-			action = function(pos, node, active_object_count, active_object_count_wider)
-				if node.name == "pipeworks:sand_tube" then
-					vacuum(pos, 2)
-				else
-					local radius = minetest.get_meta(pos):get_int("dist")
-					vacuum(pos, radius)
-				end
-			end
-})
+
+-- override the item entity that items become vacuumed if they were dropped
+local item_entity = minetest.registered_entities["__builtin:item"]
+local old_on_step = item_entity.on_step or function()end
+local old_on_activate = item_entity.on_activate or function()end
+
+item_entity.on_activate = function(self, ...)
+	old_on_activate(self, ...)
+	self.pipeworks_timer = update_interval-vacuuming_speed
+end
+
+item_entity.on_step = function(self, dtime)
+	local timer = self.pipeworks_timer
+	timer = timer+dtime
+	if timer >= update_interval then
+		if get_vacuumed(self.object) then
+			return
+		end
+		timer = vector.length(self.object:getvelocity())
+	end
+	self.pipeworks_timer = timer
+	old_on_step(self, dtime)
+end
+
+minetest.register_entity(":__builtin:item", item_entity)
+
+--[[ doing it in the first on_step is enough
+local spawn_item = minetest.add_item
+function minetest.add_item(...)
+	local obj = spawn_item(...)
+	if obj then
+		get_vacuumed(obj)
+		return obj
+	end
+end--]]


### PR DESCRIPTION
The abm thought that not adjustable sand pipes are called "pipeworks:sand_tube" but they have more names, e.g. "pipeworks:sand_tube_1".
And l increased the picking up speed that you don't need to wait for the abm until dropped items get picked up.

https://github.com/VanessaE/pipeworks/pull/115/files?w=1